### PR TITLE
ci: add Java checks workflow for assessment-service-versapath

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Backend CI
+name: CI - assessment-service-versapath
 
 on:
   pull_request:
@@ -7,7 +7,7 @@ on:
     branches: [dev]
 
 jobs:
-  build-test:
+  java-checks:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -18,6 +18,17 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
+          cache: maven
+
+      - name: Download Common events settings file
+        run: |
+          if curl -f -o settings.xml https://raw.githubusercontent.com/AmaliTech-Training-Academy/config-repository-versapath/refs/heads/dev/settings.xml; then
+            echo "Successfully downloaded settings.xml"
+            cat settings.xml
+          else
+            echo "Failed to download settings.xml, using default Maven settings"
+            echo "This may cause issues if private repositories are required"
+          fi
 
       - name: Cache Maven packages
         uses: actions/cache@v4
@@ -27,15 +38,45 @@ jobs:
           restore-keys: |
             maven-${{ runner.os }}-
 
+      - name: Verify dependencies
+        run: |
+          if [[ -f settings.xml ]]; then
+            mvn -s settings.xml -B -DskipTests dependency:resolve
+          else
+            mvn -B -DskipTests dependency:resolve
+          fi
+        env:
+          GH_USER: ${{ secrets.COMMON_EVENT_DEP_GH_USER }}
+          GH_TOKEN: ${{ secrets.COMMON_EVENT_DEP_GH_TOKEN }}
+
       - name: Build with Maven
-        run: mvn -B clean install
+        run: |
+          if [[ -f settings.xml ]]; then
+            mvn -s settings.xml -B clean compile
+          else
+            mvn -B clean compile
+          fi
+        env:
+          GH_USER: ${{ secrets.COMMON_EVENT_DEP_GH_USER  }}
+          GH_TOKEN: ${{ secrets.COMMON_EVENT_DEP_GH_TOKEN }}
 
       - name: Run tests
-        run: mvn test
+        run: |
+          if [[ -f settings.xml ]]; then
+            mvn -s settings.xml test
+          else
+            mvn test
+          fi
+        env:
+          GH_USER: ${{ secrets.COMMON_EVENT_DEP_GH_USER  }}
+          GH_TOKEN: ${{ secrets.COMMON_EVENT_DEP_GH_TOKEN }}
 
-      - name: Upload test results
+      - name: Upload build artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-results
-          path: target/surefire-reports/
+          name: build-artifacts-${{ github.run_id }}
+          path: |
+            target/surefire-reports/
+            settings.xml
+          retention-days: 30


### PR DESCRIPTION
Adds a minimal CI pipeline to run Java/Maven checks.

## What this adds:
- Java 21 setup with Temurin distribution
- Maven dependency caching
- Build and test execution
- Test results upload as artifacts
- Fallback to default Maven settings if custom settings.xml unavailable

## Requirements:
- Repository secrets `COMMON_EVENTS_GH_USER` and `COMMON_EVENTS_GH_TOKEN` should be configured if private dependencies are used