### PR TITLE
Persist user-snapshot and create assessment result Model

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 		<dependency>
 			<groupId>org.common</groupId>
 			<artifactId>versapath-events</artifactId>
-			<version>3.1</version>
+			<version>3.1.9</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/capstone/assessment_service/exception/GlobalException.java
+++ b/src/main/java/com/capstone/assessment_service/exception/GlobalException.java
@@ -226,4 +226,30 @@ public class GlobalException {
         return new ResponseEntity<>(response, HttpStatus.CONFLICT);
     }
 
+    @ExceptionHandler(UserExistsException.class)
+    public ResponseEntity<ClientResponseFormatDto> handleUserExists
+            (UserExistsException exception) {
+
+        ClientResponseFormatDto response = ClientResponseFormatDto.builder()
+                .success(false)
+                .message(exception.getMessage())
+                .errors(null)
+                .data(null)
+                .build();
+        return new ResponseEntity<>(response, HttpStatus.CONFLICT);
+    }
+
+    @ExceptionHandler(UserNotFoundException.class)
+    public ResponseEntity<ClientResponseFormatDto> handleUserNotfound
+            (UserNotFoundException exception) {
+
+        ClientResponseFormatDto response = ClientResponseFormatDto.builder()
+                .success(false)
+                .message(exception.getMessage())
+                .errors(null)
+                .data(null)
+                .build();
+        return new ResponseEntity<>(response, HttpStatus.CONFLICT);
+    }
+
 }

--- a/src/main/java/com/capstone/assessment_service/exception/UserExistsException.java
+++ b/src/main/java/com/capstone/assessment_service/exception/UserExistsException.java
@@ -1,0 +1,7 @@
+package com.capstone.assessment_service.exception;
+
+public class UserExistsException extends AppException{
+    public UserExistsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/capstone/assessment_service/exception/UserNotFoundException.java
+++ b/src/main/java/com/capstone/assessment_service/exception/UserNotFoundException.java
@@ -1,0 +1,7 @@
+package com.capstone.assessment_service.exception;
+
+public class UserNotFoundException extends AppException{
+    public UserNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/capstone/assessment_service/messaging/CreateUserListener.java
+++ b/src/main/java/com/capstone/assessment_service/messaging/CreateUserListener.java
@@ -1,5 +1,6 @@
 package com.capstone.assessment_service.messaging;
 
+import com.capstone.assessment_service.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.common.event.ProduceUserEvent;
 import org.slf4j.Logger;
@@ -11,9 +12,11 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class CreateUserListener {
     private static final Logger logger = LoggerFactory.getLogger(CreateUserListener.class);
+    private final UserService userService;
     @KafkaListener(topics = "${USER_CREATE_TOPIC}")
-
     public void createUser(ProduceUserEvent event) {
         logger.info("Start creating user event {}", event);
+
+        userService.createUser(event); // store user info in the database
     }
 }

--- a/src/main/java/com/capstone/assessment_service/messaging/CreateUserListener.java
+++ b/src/main/java/com/capstone/assessment_service/messaging/CreateUserListener.java
@@ -1,0 +1,19 @@
+package com.capstone.assessment_service.messaging;
+
+import lombok.RequiredArgsConstructor;
+import org.common.event.ProduceUserEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CreateUserListener {
+    private static final Logger logger = LoggerFactory.getLogger(CreateUserListener.class);
+    @KafkaListener(topics = "${USER_CREATE_TOPIC}")
+
+    public void createUser(ProduceUserEvent event) {
+        logger.info("Start creating user event {}", event);
+    }
+}

--- a/src/main/java/com/capstone/assessment_service/model/AssessmentResultEntity.java
+++ b/src/main/java/com/capstone/assessment_service/model/AssessmentResultEntity.java
@@ -1,0 +1,62 @@
+package com.capstone.assessment_service.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "assessment_result")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AssessmentResultEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "assessment_id", nullable = false)
+    private AssessmentEntity assessment;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "learner_id", nullable = false)
+    private UserSnapshot learner;
+
+    @Column(name = "started_at")
+    private LocalDateTime startedAt;
+
+    @Column(name = "submitted_at")
+    private LocalDateTime submittedAt;
+
+    private boolean score;
+
+    @Column(name = "attempt_number")
+    private int attemptNumber;
+
+    @Column(name = "is_passed")
+    private boolean isPassed;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/capstone/assessment_service/model/UserSnapshot.java
+++ b/src/main/java/com/capstone/assessment_service/model/UserSnapshot.java
@@ -1,0 +1,62 @@
+package com.capstone.assessment_service.model;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "user_snapshot")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserSnapshot {
+    @Id
+    private UUID id;
+
+    @Email(message = "Email should be valid")
+    @NotBlank(message = "Email is required")
+    @Size(max = 255, message = "Email must not exceed 255 characters")
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @NotBlank(message = "Username is required")
+    @Size(max = 100, message = "Username must not exceed 100 characters")
+    @Column(nullable = false, unique = true)
+    private String username;
+
+    @NotBlank(message = "First name is required")
+    @Size(max = 255, message = "First name must not exceed 255 characters")
+    @Column(name = "first_name", nullable = false)
+    private String firstName;
+
+    @NotBlank(message = "Last name is required")
+    @Size(max = 255, message = "Last name must not exceed 255 characters")
+    @Column(name = "last_name", nullable = false)
+    private String lastName;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/capstone/assessment_service/repository/UserSnapshotRepository.java
+++ b/src/main/java/com/capstone/assessment_service/repository/UserSnapshotRepository.java
@@ -1,0 +1,12 @@
+package com.capstone.assessment_service.repository;
+
+import com.capstone.assessment_service.model.UserSnapshot;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface UserSnapshotRepository extends JpaRepository<UserSnapshot, UUID> {
+
+}

--- a/src/main/java/com/capstone/assessment_service/service/UserService.java
+++ b/src/main/java/com/capstone/assessment_service/service/UserService.java
@@ -1,0 +1,7 @@
+package com.capstone.assessment_service.service;
+
+import org.common.event.ProduceUserEvent;
+
+public interface UserService {
+    void createUser(ProduceUserEvent userDto);
+}

--- a/src/main/java/com/capstone/assessment_service/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/capstone/assessment_service/service/impl/UserServiceImpl.java
@@ -1,0 +1,40 @@
+package com.capstone.assessment_service.service.impl;
+
+import com.capstone.assessment_service.exception.UserExistsException;
+import com.capstone.assessment_service.model.UserSnapshot;
+import com.capstone.assessment_service.repository.UserSnapshotRepository;
+import com.capstone.assessment_service.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.common.event.ProduceUserEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+    private static final Logger logger = LoggerFactory.getLogger(UserServiceImpl.class);
+    private final UserSnapshotRepository userSnapshotRepository;
+    @Override
+    public void createUser(ProduceUserEvent userDto) {
+       if(userSnapshotRepository.findById(userDto.getVersapathUserId()).isPresent()){
+           throw new UserExistsException("The use provided already exists!!");
+       }
+
+        UserSnapshot userSnapshot = UserSnapshot.builder()
+                .id(userDto.getVersapathUserId())
+                .email(userDto.getEmail())
+                .lastName(userDto.getLastName())
+                .firstName(userDto.getFirstName())
+                .username(userDto.getUsername())
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+       userSnapshotRepository.save(userSnapshot);
+
+       logger.info("User inserted successfully!!");
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,8 +26,8 @@ spring:
       value-deserializer: org.springframework.kafka.support.serializer.ErrorHandlingDeserializer
       properties:
         spring.deserializer.value.delegate.class: org.springframework.kafka.support.serializer.JsonDeserializer
-        spring.json.value.default.type: org.common.event.SkillCapsuleEvent
         spring.json.trusted.packages: "*"
+        spring.json.use.type.headers: true
 
 management:
   endpoints:


### PR DESCRIPTION
# 🚀 Pull Request: Store user-snapshot in the database

### 🎫 Jira Ticket  
[🔗 SPRINT-3/VER-24:Store learner's assessment result in Versapath database.](https://amali-tech.atlassian.net/browse/VER-164)

---

## ✅ Summary

This PR stores the user snapshot in the database and creates the assessment result model.

---

## 📌 Feature

- [x] Create user snapshot and assessment result Models
- [x] Listen to user snapshot event
- [x] Persist user information into the database

---

## 🚧 Next Task

- Persist the learner's assessment result in the database
- Implement update, view, and delete operations for the assessment entity.
- Integrate security in the assessment service.