### PR TITLE
Store learner's assessment result in the Versapath database

### DIFF
--- a/src/main/java/com/capstone/assessment_service/messaging/CreateAssessmentResultListenerEvent.java
+++ b/src/main/java/com/capstone/assessment_service/messaging/CreateAssessmentResultListenerEvent.java
@@ -1,0 +1,22 @@
+package com.capstone.assessment_service.messaging;
+
+import com.capstone.assessment_service.service.AssessmentService;
+import lombok.RequiredArgsConstructor;
+import org.common.event.AssessmentResultEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CreateAssessmentResultListenerEvent {
+    private static final Logger logger = LoggerFactory.getLogger(CreateAssessmentResultListenerEvent.class);
+    private final AssessmentService assessmentService;
+
+    @RabbitListener(queues = "${ASSESSMENT_RESULT_QUEUE}")
+    public void handleMoodleUserCreation(AssessmentResultEvent event) {
+        logger.info("Start inserting assessment result to the database: {}", event);
+
+    }
+}

--- a/src/main/java/com/capstone/assessment_service/messaging/CreateAssessmentResultListenerEvent.java
+++ b/src/main/java/com/capstone/assessment_service/messaging/CreateAssessmentResultListenerEvent.java
@@ -18,5 +18,6 @@ public class CreateAssessmentResultListenerEvent {
     public void handleMoodleUserCreation(AssessmentResultEvent event) {
         logger.info("Start inserting assessment result to the database: {}", event);
 
+        assessmentService.createAssessmentResult(event); // insert assessment result into DB
     }
 }

--- a/src/main/java/com/capstone/assessment_service/messaging/PopulateAssessmentEvents.java
+++ b/src/main/java/com/capstone/assessment_service/messaging/PopulateAssessmentEvents.java
@@ -1,0 +1,26 @@
+package com.capstone.assessment_service.messaging;
+
+import lombok.RequiredArgsConstructor;
+import org.common.event.AssessmentResultEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PopulateAssessmentEvents {
+    private static final Logger logger = LoggerFactory.getLogger(PopulateAssessmentEvents.class);
+    private final KafkaTemplate<String, AssessmentResultEvent> kafkaClusterTemplate;
+
+    @Value("${ASSESSMENT_RESULT_TOPIC}")
+    private String assessmentResult;
+
+    public void populateCreateAssessmentResult(AssessmentResultEvent event){
+        kafkaClusterTemplate.send(assessmentResult, event);
+
+        logger.info("create assessment result is populated: {}", event);
+    }
+
+}

--- a/src/main/java/com/capstone/assessment_service/model/AssessmentResultEntity.java
+++ b/src/main/java/com/capstone/assessment_service/model/AssessmentResultEntity.java
@@ -34,7 +34,7 @@ public class AssessmentResultEntity {
     @Column(name = "submitted_at")
     private LocalDateTime submittedAt;
 
-    private boolean score;
+    private double score;
 
     @Column(name = "attempt_number")
     private int attemptNumber;

--- a/src/main/java/com/capstone/assessment_service/repository/AssessmentRepository.java
+++ b/src/main/java/com/capstone/assessment_service/repository/AssessmentRepository.java
@@ -10,4 +10,5 @@ import java.util.UUID;
 @Repository
 public interface AssessmentRepository extends JpaRepository<AssessmentEntity, UUID> {
     Optional<AssessmentEntity> findByAssessmentName(String name);
+    Optional<AssessmentEntity> findByMoodleQuizId(int moodleQuizId);
 }

--- a/src/main/java/com/capstone/assessment_service/repository/AssessmentResultRepository.java
+++ b/src/main/java/com/capstone/assessment_service/repository/AssessmentResultRepository.java
@@ -1,0 +1,11 @@
+package com.capstone.assessment_service.repository;
+
+import com.capstone.assessment_service.model.AssessmentResultEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface AssessmentResultRepository extends JpaRepository<AssessmentResultEntity, UUID> {
+}

--- a/src/main/java/com/capstone/assessment_service/service/AssessmentService.java
+++ b/src/main/java/com/capstone/assessment_service/service/AssessmentService.java
@@ -3,6 +3,7 @@ package com.capstone.assessment_service.service;
 import com.capstone.assessment_service.dto.assessment.AssessmentRequestDto;
 import com.capstone.assessment_service.dto.assessment.AssessmentResponseDto;
 import com.capstone.assessment_service.model.AssessmentEntity;
+import org.common.event.AssessmentResultEvent;
 import org.common.event.AssessmentUpdateEvent;
 import org.springframework.stereotype.Repository;
 
@@ -12,4 +13,5 @@ public interface AssessmentService {
     AssessmentResponseDto create(AssessmentRequestDto dto);
     Optional<AssessmentEntity> findByName(String name);
     void updateAssessmentWithMoodleData(AssessmentUpdateEvent assessmentUpdateEvent);
+    void createAssessmentResult(AssessmentResultEvent event);
 }

--- a/src/main/java/com/capstone/assessment_service/service/impl/AssessmentServiceImpl.java
+++ b/src/main/java/com/capstone/assessment_service/service/impl/AssessmentServiceImpl.java
@@ -7,6 +7,7 @@ import com.capstone.assessment_service.exception.CapsuleNotFoundException;
 import com.capstone.assessment_service.exception.UserNotFoundException;
 import com.capstone.assessment_service.mapper.AssessmentMapper;
 import com.capstone.assessment_service.messaging.CreateAssessmentOnMoodleProducerEvent;
+import com.capstone.assessment_service.messaging.PopulateAssessmentEvents;
 import com.capstone.assessment_service.model.AssessmentEntity;
 import com.capstone.assessment_service.model.AssessmentResultEntity;
 import com.capstone.assessment_service.model.SkillCapsuleEntity;
@@ -38,6 +39,7 @@ public class AssessmentServiceImpl implements AssessmentService {
     private final CreateAssessmentOnMoodleProducerEvent createAssessmentOnMoodleProducerEvent;
     private final AssessmentResultRepository assessmentResultRepository;
     private final UserSnapshotRepository userSnapshotRepository;
+    private final PopulateAssessmentEvents populateAssessmentEvents;
 
     @Override
     public AssessmentResponseDto create(AssessmentRequestDto dto) {
@@ -105,7 +107,10 @@ public class AssessmentServiceImpl implements AssessmentService {
                 .submittedAt(event.getTimeFinish())
                 .build();
 
-        assessmentResultRepository.save(assessmentResult);
+
+        AssessmentResultEntity assessmentResultEntity = assessmentResultRepository.save(assessmentResult);
+
+        populateAssessmentResult(assessmentResultEntity);
 
         logger.info("Assessment result inserted successfully");
     }
@@ -122,5 +127,23 @@ public class AssessmentServiceImpl implements AssessmentService {
                 .build();
 
         createAssessmentOnMoodleProducerEvent.createAssessmentOnMoodle(assessmentEvent);
+    }
+
+    private void populateAssessmentResult(AssessmentResultEntity assessmentResult ){
+        AssessmentResultEvent assessmentResultEvent = AssessmentResultEvent.builder()
+                .userId(assessmentResult.getLearner().getId())
+                .assessmentName(assessmentResult.getAssessment().getAssessmentName())
+                .assessmentId(assessmentResult.getAssessment().getId())
+                .timeStart(assessmentResult.getStartedAt())
+                .timeFinish(assessmentResult.getSubmittedAt())
+                .moodleQuizId(assessmentResult.getAssessment().getMoodleQuizId())
+                .attemptNumber(assessmentResult.getAttemptNumber())
+                .grade(assessmentResult.getScore())
+                .build();
+
+        populateAssessmentEvents.populateCreateAssessmentResult(assessmentResultEvent);
+
+        logger.info("Assessment result populated successfully {}", assessmentResultEvent);
+
     }
 }

--- a/src/main/java/com/capstone/assessment_service/service/impl/AssessmentServiceImpl.java
+++ b/src/main/java/com/capstone/assessment_service/service/impl/AssessmentServiceImpl.java
@@ -4,15 +4,21 @@ import com.capstone.assessment_service.dto.assessment.AssessmentRequestDto;
 import com.capstone.assessment_service.dto.assessment.AssessmentResponseDto;
 import com.capstone.assessment_service.exception.AssessmentExistsException;
 import com.capstone.assessment_service.exception.CapsuleNotFoundException;
+import com.capstone.assessment_service.exception.UserNotFoundException;
 import com.capstone.assessment_service.mapper.AssessmentMapper;
 import com.capstone.assessment_service.messaging.CreateAssessmentOnMoodleProducerEvent;
 import com.capstone.assessment_service.model.AssessmentEntity;
+import com.capstone.assessment_service.model.AssessmentResultEntity;
 import com.capstone.assessment_service.model.SkillCapsuleEntity;
+import com.capstone.assessment_service.model.UserSnapshot;
 import com.capstone.assessment_service.repository.AssessmentRepository;
+import com.capstone.assessment_service.repository.AssessmentResultRepository;
+import com.capstone.assessment_service.repository.UserSnapshotRepository;
 import com.capstone.assessment_service.service.AssessmentService;
 import com.capstone.assessment_service.service.CapsuleService;
 import lombok.RequiredArgsConstructor;
 import org.common.event.AssessmentEvent;
+import org.common.event.AssessmentResultEvent;
 import org.common.event.AssessmentUpdateEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,6 +36,8 @@ public class AssessmentServiceImpl implements AssessmentService {
     private final CapsuleService capsuleService;
     private final AssessmentMapper assessmentMapper;
     private final CreateAssessmentOnMoodleProducerEvent createAssessmentOnMoodleProducerEvent;
+    private final AssessmentResultRepository assessmentResultRepository;
+    private final UserSnapshotRepository userSnapshotRepository;
 
     @Override
     public AssessmentResponseDto create(AssessmentRequestDto dto) {
@@ -75,6 +83,31 @@ public class AssessmentServiceImpl implements AssessmentService {
         assessmentRepository.save(assessment);
 
         logger.info("Assessment updated successfully {}", assessment.getAssessmentName());
+    }
+
+    @Override
+    public void createAssessmentResult(AssessmentResultEvent event) {
+        AssessmentEntity assessment = assessmentRepository.findByMoodleQuizId(event.getMoodleQuizId())
+                .orElseThrow( () -> new AssessmentExistsException("Assessment provided doesn't exist")
+                );
+
+        UserSnapshot leaner = userSnapshotRepository.findById(event.getUserId())
+                .orElseThrow( () -> new UserNotFoundException("User provided doesn't exist")
+                );
+
+        AssessmentResultEntity assessmentResult = AssessmentResultEntity.builder()
+                .assessment(assessment)
+                .learner(leaner)
+                .attemptNumber(event.getAttemptNumber())
+                .score(event.getGrade())
+                .isPassed(event.getGrade() >= assessment.getPassingScore())
+                .startedAt(event.getTimeStart())
+                .submittedAt(event.getTimeFinish())
+                .build();
+
+        assessmentResultRepository.save(assessmentResult);
+
+        logger.info("Assessment result inserted successfully");
     }
 
     void sendCommandToCreateAssessmentOnMoodle(AssessmentEntity savedAssessment){

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,6 +29,10 @@ spring:
         spring.json.trusted.packages: "*"
         spring.json.use.type.headers: true
 
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+
 management:
   endpoints:
     web:


### PR DESCRIPTION
# 🚀 Pull Request: Store assessment result in the database

### 🎫 Jira Ticket  
[🔗 SPRINT-3/VER-24:Store learner's assessment result in Versapath database.](https://amali-tech.atlassian.net/browse/VER-164)

---

## ✅ Summary

This PR stores the learner’s assessment information coming from Moodle in the Versapath database for analysis and readiness.

---

## 📌 Feature

- [x] Listen to the assessment result event
- [x] Persist assessment result into the database
- [x] Publish assessment result event 

---

## 🚧 Next Task

- Implement update, view, and delete operations for the assessment entity.
- Integrate security in the assessment service.