### PR TITLE
Filter and retrieve assessments information

### DIFF
--- a/src/main/java/com/capstone/assessment_service/controller/AssessmentController.java
+++ b/src/main/java/com/capstone/assessment_service/controller/AssessmentController.java
@@ -16,7 +16,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
@@ -65,6 +67,19 @@ public class AssessmentController {
         ClientResponseFormatDto response = ClientResponseFormatDto.builder()
                 .success(true)
                 .message("Filter assessments")
+                .errors(null)
+                .data(assessments)
+                .build();
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @GetMapping("/{capsuleId}/capsule")
+    @Operation(summary = "Retrieve assessments by capsule", description = "This end point allows the fetching of all assessments by capsule")
+    public ResponseEntity<ClientResponseFormatDto> fetchAssessmentsByCapsule(@PathVariable UUID capsuleId) {
+        List<AssessmentResponseDto> assessments = this.assessmentService.findByCapsuleId(capsuleId);
+        ClientResponseFormatDto response = ClientResponseFormatDto.builder()
+                .success(true)
+                .message("Fetch all assessments by capsule")
                 .errors(null)
                 .data(assessments)
                 .build();

--- a/src/main/java/com/capstone/assessment_service/controller/AssessmentController.java
+++ b/src/main/java/com/capstone/assessment_service/controller/AssessmentController.java
@@ -9,7 +9,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -45,6 +47,24 @@ public class AssessmentController {
         ClientResponseFormatDto response = ClientResponseFormatDto.builder()
                 .success(true)
                 .message("Fetch all assessments")
+                .errors(null)
+                .data(assessments)
+                .build();
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @GetMapping("/filter")
+    @Operation(summary = "Filter assessments", description = "This end point allows the filtering assessments by name")
+    public ResponseEntity<ClientResponseFormatDto> filterAssessments(
+            @RequestParam(required = false) String name,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "${PAGE_SIZE}") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+        CustomPageResponse<AssessmentResponseDto> assessments = this.assessmentService.filter(name, pageable);
+        ClientResponseFormatDto response = ClientResponseFormatDto.builder()
+                .success(true)
+                .message("Filter assessments")
                 .errors(null)
                 .data(assessments)
                 .build();

--- a/src/main/java/com/capstone/assessment_service/controller/AssessmentController.java
+++ b/src/main/java/com/capstone/assessment_service/controller/AssessmentController.java
@@ -1,6 +1,7 @@
 package com.capstone.assessment_service.controller;
 
 import com.capstone.assessment_service.dto.ClientResponseFormatDto;
+import com.capstone.assessment_service.dto.CustomPageResponse;
 import com.capstone.assessment_service.dto.assessment.AssessmentRequestDto;
 import com.capstone.assessment_service.dto.assessment.AssessmentResponseDto;
 import com.capstone.assessment_service.service.AssessmentService;
@@ -8,12 +9,10 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
 
@@ -26,7 +25,7 @@ public class AssessmentController {
 
     @PostMapping()
     @Operation(summary = "Create an assessment", description = "This end point creates a skill assessment metadata")
-    public ResponseEntity<ClientResponseFormatDto> createAtom(
+    public ResponseEntity<ClientResponseFormatDto> createAssessment(
             @Valid @RequestBody AssessmentRequestDto assessmentRequestDto
     ) {
         AssessmentResponseDto savedAssessment = assessmentService.create(assessmentRequestDto);
@@ -37,5 +36,18 @@ public class AssessmentController {
                 .data(Map.of("item", savedAssessment))
                 .build();
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping()
+    @Operation(summary = "Retrieve assessments", description = "This end point allows the fetching of all assessments")
+    public ResponseEntity<ClientResponseFormatDto> fetchAllAssessments(Pageable pageable) {
+        CustomPageResponse<AssessmentResponseDto> assessments = this.assessmentService.findAll(pageable);
+        ClientResponseFormatDto response = ClientResponseFormatDto.builder()
+                .success(true)
+                .message("Fetch all assessments")
+                .errors(null)
+                .data(assessments)
+                .build();
+        return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 }

--- a/src/main/java/com/capstone/assessment_service/dto/assessment/AssessmentRequestDto.java
+++ b/src/main/java/com/capstone/assessment_service/dto/assessment/AssessmentRequestDto.java
@@ -20,7 +20,7 @@ public class AssessmentRequestDto {
     private String assessmentType;
 
     @Min(value = 1, message = "Max attempts Must be at least 1")
-    @Max(value = 1000, message = "Max attempts Must not exceed 1000")
+    @Max(value = 100, message = "Max attempts Must not exceed 1000")
     private int maxAttempts;
 
     @Min(value = 1, message = "Time limit Must be at least 1")
@@ -28,9 +28,11 @@ public class AssessmentRequestDto {
     private int timeLimitMinutes;
 
     @Min(value = 1, message = "Passing Score Must be at least 1")
-    @Max(value = 1000, message = "Passing Score Must not exceed 1000")
+    @Max(value = 100, message = "Passing Score Must not exceed 1000")
     private int passingScore;
 
     private String instructions;
+    private String status;
+    private String description;
     private UUID skillCapsuleId;
 }

--- a/src/main/java/com/capstone/assessment_service/dto/assessment/AssessmentRequestDto.java
+++ b/src/main/java/com/capstone/assessment_service/dto/assessment/AssessmentRequestDto.java
@@ -20,7 +20,7 @@ public class AssessmentRequestDto {
     private String assessmentType;
 
     @Min(value = 1, message = "Max attempts Must be at least 1")
-    @Max(value = 100, message = "Max attempts Must not exceed 1000")
+    @Max(value = 100, message = "Max attempts Must not exceed 100")
     private int maxAttempts;
 
     @Min(value = 1, message = "Time limit Must be at least 1")
@@ -28,7 +28,7 @@ public class AssessmentRequestDto {
     private int timeLimitMinutes;
 
     @Min(value = 1, message = "Passing Score Must be at least 1")
-    @Max(value = 100, message = "Passing Score Must not exceed 1000")
+    @Max(value = 100, message = "Passing Score Must not exceed 100")
     private int passingScore;
 
     private String instructions;

--- a/src/main/java/com/capstone/assessment_service/dto/assessment/AssessmentResponseDto.java
+++ b/src/main/java/com/capstone/assessment_service/dto/assessment/AssessmentResponseDto.java
@@ -18,5 +18,5 @@ public class AssessmentResponseDto {
     private int maxAttempts;
     private int timeLimitMinutes;
     private int passingScore;
-
+    private int moodleQuizId;
 }

--- a/src/main/java/com/capstone/assessment_service/dto/assessment/AssessmentResponseDto.java
+++ b/src/main/java/com/capstone/assessment_service/dto/assessment/AssessmentResponseDto.java
@@ -13,6 +13,8 @@ public class AssessmentResponseDto {
     private String assessmentName;
     private String assessmentType;
     private String capsuleName;
+    private String description;
+    private String status;
     private int maxAttempts;
     private int timeLimitMinutes;
     private int passingScore;

--- a/src/main/java/com/capstone/assessment_service/model/AssessmentEntity.java
+++ b/src/main/java/com/capstone/assessment_service/model/AssessmentEntity.java
@@ -44,6 +44,11 @@ public class AssessmentEntity {
     @Column(name = "moodle_course_module_id")
     private int moodleCourseModuleId;
 
+    private String status;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "skill_capsule_id", nullable = false)
     private SkillCapsuleEntity capsule;

--- a/src/main/java/com/capstone/assessment_service/repository/AssessmentRepository.java
+++ b/src/main/java/com/capstone/assessment_service/repository/AssessmentRepository.java
@@ -1,6 +1,8 @@
 package com.capstone.assessment_service.repository;
 
 import com.capstone.assessment_service.model.AssessmentEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,4 +12,5 @@ import java.util.UUID;
 @Repository
 public interface AssessmentRepository extends JpaRepository<AssessmentEntity, UUID> {
     Optional<AssessmentEntity> findByAssessmentName(String name);
+    Page<AssessmentEntity> findByAssessmentNameContainingIgnoreCase(String name, Pageable pageable);
 }

--- a/src/main/java/com/capstone/assessment_service/repository/AssessmentRepository.java
+++ b/src/main/java/com/capstone/assessment_service/repository/AssessmentRepository.java
@@ -4,8 +4,11 @@ import com.capstone.assessment_service.model.AssessmentEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -13,4 +16,11 @@ import java.util.UUID;
 public interface AssessmentRepository extends JpaRepository<AssessmentEntity, UUID> {
     Optional<AssessmentEntity> findByAssessmentName(String name);
     Page<AssessmentEntity> findByAssessmentNameContainingIgnoreCase(String name, Pageable pageable);
+
+    @Query("""
+    SELECT a
+    FROM AssessmentEntity a
+    WHERE a.capsule.id = :capsuleId
+    """)
+    List<AssessmentEntity> findByCapsuleId(@Param("capsuleId") UUID capsuleId);
 }

--- a/src/main/java/com/capstone/assessment_service/service/AssessmentService.java
+++ b/src/main/java/com/capstone/assessment_service/service/AssessmentService.java
@@ -14,4 +14,5 @@ public interface AssessmentService {
     Optional<AssessmentEntity> findByName(String name);
     void updateAssessmentWithMoodleData(AssessmentUpdateEvent assessmentUpdateEvent);
     CustomPageResponse<AssessmentResponseDto> findAll(Pageable pageable);
+    CustomPageResponse<AssessmentResponseDto> filter(String name, Pageable pageable);
 }

--- a/src/main/java/com/capstone/assessment_service/service/AssessmentService.java
+++ b/src/main/java/com/capstone/assessment_service/service/AssessmentService.java
@@ -7,7 +7,9 @@ import com.capstone.assessment_service.model.AssessmentEntity;
 import org.common.event.AssessmentUpdateEvent;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 public interface AssessmentService {
     AssessmentResponseDto create(AssessmentRequestDto dto);
@@ -15,4 +17,5 @@ public interface AssessmentService {
     void updateAssessmentWithMoodleData(AssessmentUpdateEvent assessmentUpdateEvent);
     CustomPageResponse<AssessmentResponseDto> findAll(Pageable pageable);
     CustomPageResponse<AssessmentResponseDto> filter(String name, Pageable pageable);
+    List<AssessmentResponseDto> findByCapsuleId(UUID capsuleId);
 }

--- a/src/main/java/com/capstone/assessment_service/service/AssessmentService.java
+++ b/src/main/java/com/capstone/assessment_service/service/AssessmentService.java
@@ -1,10 +1,11 @@
 package com.capstone.assessment_service.service;
 
+import com.capstone.assessment_service.dto.CustomPageResponse;
 import com.capstone.assessment_service.dto.assessment.AssessmentRequestDto;
 import com.capstone.assessment_service.dto.assessment.AssessmentResponseDto;
 import com.capstone.assessment_service.model.AssessmentEntity;
 import org.common.event.AssessmentUpdateEvent;
-import org.springframework.stereotype.Repository;
+import org.springframework.data.domain.Pageable;
 
 import java.util.Optional;
 
@@ -12,4 +13,5 @@ public interface AssessmentService {
     AssessmentResponseDto create(AssessmentRequestDto dto);
     Optional<AssessmentEntity> findByName(String name);
     void updateAssessmentWithMoodleData(AssessmentUpdateEvent assessmentUpdateEvent);
+    CustomPageResponse<AssessmentResponseDto> findAll(Pageable pageable);
 }

--- a/src/main/java/com/capstone/assessment_service/service/impl/AssessmentServiceImpl.java
+++ b/src/main/java/com/capstone/assessment_service/service/impl/AssessmentServiceImpl.java
@@ -1,5 +1,7 @@
 package com.capstone.assessment_service.service.impl;
 
+import com.capstone.assessment_service.dto.CustomPageResponse;
+import com.capstone.assessment_service.dto.PaginationData;
 import com.capstone.assessment_service.dto.assessment.AssessmentRequestDto;
 import com.capstone.assessment_service.dto.assessment.AssessmentResponseDto;
 import com.capstone.assessment_service.exception.AssessmentExistsException;
@@ -17,6 +19,8 @@ import org.common.event.AssessmentUpdateEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -75,6 +79,24 @@ public class AssessmentServiceImpl implements AssessmentService {
         assessmentRepository.save(assessment);
 
         logger.info("Assessment updated successfully {}", assessment.getAssessmentName());
+    }
+
+    @Override
+    public CustomPageResponse<AssessmentResponseDto> findAll(Pageable pageable) {
+        Page<AssessmentEntity> assessmentList = assessmentRepository.findAll(pageable);
+        Page<AssessmentResponseDto> assessments = assessmentList.map(assessmentMapper::toResponseDto);
+
+        return CustomPageResponse.<AssessmentResponseDto>builder()
+                .items(assessments.getContent())
+                .pagination(PaginationData.builder()
+                        .page(assessments.getNumber())
+                        .size(assessments.getSize())
+                        .totalElements(assessments.getTotalElements())
+                        .totalPages(assessments.getTotalPages())
+                        .hasNext(assessments.hasNext())
+                        .hasPrevious(assessments.hasPrevious())
+                        .build())
+                .build();
     }
 
     void sendCommandToCreateAssessmentOnMoodle(AssessmentEntity savedAssessment){

--- a/src/main/java/com/capstone/assessment_service/service/impl/AssessmentServiceImpl.java
+++ b/src/main/java/com/capstone/assessment_service/service/impl/AssessmentServiceImpl.java
@@ -20,6 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
@@ -85,6 +86,36 @@ public class AssessmentServiceImpl implements AssessmentService {
     public CustomPageResponse<AssessmentResponseDto> findAll(Pageable pageable) {
         Page<AssessmentEntity> assessmentList = assessmentRepository.findAll(pageable);
         Page<AssessmentResponseDto> assessments = assessmentList.map(assessmentMapper::toResponseDto);
+
+        logger.info("Assessment fetched successfully");
+
+        return CustomPageResponse.<AssessmentResponseDto>builder()
+                .items(assessments.getContent())
+                .pagination(PaginationData.builder()
+                        .page(assessments.getNumber())
+                        .size(assessments.getSize())
+                        .totalElements(assessments.getTotalElements())
+                        .totalPages(assessments.getTotalPages())
+                        .hasNext(assessments.hasNext())
+                        .hasPrevious(assessments.hasPrevious())
+                        .build())
+                .build();
+    }
+
+    @Override
+    public CustomPageResponse<AssessmentResponseDto> filter(String name, Pageable pageable) {
+
+        Page<AssessmentEntity> assessmentList= null;
+        // if assessment name isn't provided fetch 20 first items
+        if(name == null || name.trim().isEmpty()){
+            assessmentList = this.assessmentRepository.findAll(PageRequest.of(0, 20));
+        }else{
+            assessmentList = this.assessmentRepository.findByAssessmentNameContainingIgnoreCase(name, pageable);
+        }
+
+        Page<AssessmentResponseDto> assessments = assessmentList.map(assessmentMapper::toResponseDto);
+
+        logger.info("Assessment filtered successfully");
 
         return CustomPageResponse.<AssessmentResponseDto>builder()
                 .items(assessments.getContent())

--- a/src/main/java/com/capstone/assessment_service/service/impl/AssessmentServiceImpl.java
+++ b/src/main/java/com/capstone/assessment_service/service/impl/AssessmentServiceImpl.java
@@ -25,7 +25,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -128,6 +130,12 @@ public class AssessmentServiceImpl implements AssessmentService {
                         .hasPrevious(assessments.hasPrevious())
                         .build())
                 .build();
+    }
+
+    @Override
+    public List<AssessmentResponseDto> findByCapsuleId(UUID capsuleId) {
+        List<AssessmentEntity> assessmentList = assessmentRepository.findByCapsuleId(capsuleId);
+        return assessmentList.stream().map(assessmentMapper::toResponseDto).toList();
     }
 
     void sendCommandToCreateAssessmentOnMoodle(AssessmentEntity savedAssessment){


### PR DESCRIPTION
# 🚀 Pull Request: Filter and retrieve assessment information

### 🎫 Jira Ticket  
[🔗 SPRINT-3/VER-24: Implement CRUD operation on assessment.](https://amali-tech.atlassian.net/browse/VER-160)

---

## ✅ Summary

This PR fetches all the assessments with pagination, filters assessments by name, and fetches assessments by capsule.

---

## 📌 Feature

- [x] Retrieve all the assessments
- [x] Filter by name
- [x] Fech assessment by capsule

---

## 🚧 Next Task

- Implement the update and delete operations for the assessment entity.
- Integrate security in the assessment service.